### PR TITLE
Add basic support for PostgreSQL 9.3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ every time when function is started.
 
 
 ## Installation
- * copy the source code to PostgreSQL's source code tree (8.4.x, 9.0.x, 9.1.x, [9.2.x]) - to _contrib_ directory
+ * copy the source code to PostgreSQL's source code tree (8.4.x, 9.0.x, 9.1.x, [9.2.x], 9.3.x) - to _contrib_ directory
  * compile it there and install it - _make; make install_
 
 ## Usage

--- a/expected/plpgsql_lint-9.3.out
+++ b/expected/plpgsql_lint-9.3.out
@@ -1,0 +1,163 @@
+load 'plpgsql';
+load 'plpgsql_lint';
+create table t1(a int, b int);
+create function f1()
+returns void as $$
+begin
+  if false then
+    update t1 set c = 30;
+  end if;
+end;
+$$ language plpgsql;
+select f1();
+ERROR:  column "c" of relation "t1" does not exist
+LINE 1: update t1 set c = 30
+                      ^
+QUERY:  update t1 set c = 30
+CONTEXT:  PL/pgSQL function f1() line 4 at SQL statement
+drop function f1();
+create function g1(out a int, out b int)
+as $$
+  select 10,20;
+$$ language sql;
+create function f1()
+returns void as $$
+declare r record;
+begin
+  r := g1();
+  if false then 
+    raise notice '%', r.c;
+  end if;
+end;
+$$ language plpgsql;
+select f1();
+ERROR:  record "r" has no field "c"
+CONTEXT:  SQL statement "SELECT r.c"
+PL/pgSQL function f1() line 6 at RAISE
+drop function f1();
+drop function g1();
+create function g1(out a int, out b int)
+returns setof record as $$
+select * from t1;
+$$ language sql;
+create function f1()
+returns void as $$
+declare r record;
+begin
+  for r in select * from g1()
+  loop
+    raise notice '%', r.c;
+  end loop;
+end;
+$$ language plpgsql;
+select f1();
+ERROR:  record "r" has no field "c"
+CONTEXT:  SQL statement "SELECT r.c"
+PL/pgSQL function f1() line 6 at RAISE
+create or replace function f1()
+returns void as $$
+declare r record;
+begin
+  for r in select * from g1()
+  loop
+    r.c := 20;
+  end loop;
+end;
+$$ language plpgsql;
+select f1();
+ERROR:  record "r" has no field "c"
+CONTEXT:  PL/pgSQL function f1() line 6 at assignment
+drop function f1();
+drop function g1();
+create function f1()
+returns int as $$
+declare r int;
+begin
+  if false then
+    r := a + b;
+  end if;
+  return r;
+end;
+$$ language plpgsql;
+select f1();
+ERROR:  column "a" does not exist
+LINE 1: SELECT a + b
+               ^
+QUERY:  SELECT a + b
+CONTEXT:  PL/pgSQL function f1() line 5 at assignment
+drop function f1();
+create or replace function f1()
+returns void as $$
+begin
+  if false then
+    raise notice '%', 1, 2;
+  end if;
+end;
+$$ language plpgsql;
+select f1();
+ERROR:  too many parameters specified for RAISE
+CONTEXT:  PL/pgSQL function f1() line 4 at RAISE
+drop function f1();
+create or replace function f1()
+returns void as $$
+begin
+  if false then
+    raise notice '% %';
+  end if;
+end;
+$$ language plpgsql;
+select f1();
+ERROR:  too few parameters specified for RAISE
+CONTEXT:  PL/pgSQL function f1() line 4 at RAISE
+drop function f1();
+create or replace function f1()
+returns void as $$
+declare r int[];
+begin
+  if false then
+    r[c+10] := 20;
+  end if;
+end;
+$$ language plpgsql;
+select f1();
+ERROR:  column "c" does not exist
+LINE 1: SELECT c+10
+               ^
+QUERY:  SELECT c+10
+CONTEXT:  PL/pgSQL function f1() line 5 at assignment
+drop function f1();
+create or replace function f1()
+returns void as $$
+declare r int;
+begin
+  if false then
+    r[10] := 20;
+  end if;
+end;
+$$ language plpgsql;
+select f1();
+ERROR:  subscripted object is not an array
+CONTEXT:  PL/pgSQL function f1() line 5 at assignment
+drop function f1();
+create type _exception_type as (
+  state text,
+  message text,
+  detail text);
+create or replace function f1()
+returns void as $$
+declare
+  _exception record;
+begin
+  _exception := NULL::_exception_type;
+exception when others then
+  get stacked diagnostics
+        _exception.state = RETURNED_SQLSTATE,
+        _exception.message = MESSAGE_TEXT,
+        _exception.detail = PG_EXCEPTION_DETAIL,
+        _exception.hint = PG_EXCEPTION_HINT;
+end;
+$$ language plpgsql;
+select f1();
+ERROR:  record "_exception" has no field "hint"
+CONTEXT:  PL/pgSQL function f1() line 7 at GET DIAGNOSTICS
+drop function f1();

--- a/plpgsql_lint.c
+++ b/plpgsql_lint.c
@@ -12,6 +12,10 @@
 #include "utils/lsyscache.h"
 #include "utils/typcache.h"
 
+#if PG_VERSION_NUM >= 90300
+#include "access/htup_details.h"
+#endif
+
 #ifdef PG_MODULE_MAGIC
 PG_MODULE_MAGIC;
 #endif

--- a/sql/plpgsql_lint-9.3.sql
+++ b/sql/plpgsql_lint-9.3.sql
@@ -1,0 +1,166 @@
+load 'plpgsql';
+load 'plpgsql_lint';
+
+create table t1(a int, b int);
+
+create function f1()
+returns void as $$
+begin
+  if false then
+    update t1 set c = 30;
+  end if;
+end;
+$$ language plpgsql;
+
+select f1();
+
+drop function f1();
+
+create function g1(out a int, out b int)
+as $$
+  select 10,20;
+$$ language sql;
+
+create function f1()
+returns void as $$
+declare r record;
+begin
+  r := g1();
+  if false then 
+    raise notice '%', r.c;
+  end if;
+end;
+$$ language plpgsql;
+
+select f1();
+
+drop function f1();
+drop function g1();
+
+create function g1(out a int, out b int)
+returns setof record as $$
+select * from t1;
+$$ language sql;
+
+create function f1()
+returns void as $$
+declare r record;
+begin
+  for r in select * from g1()
+  loop
+    raise notice '%', r.c;
+  end loop;
+end;
+$$ language plpgsql;
+
+select f1();
+
+create or replace function f1()
+returns void as $$
+declare r record;
+begin
+  for r in select * from g1()
+  loop
+    r.c := 20;
+  end loop;
+end;
+$$ language plpgsql;
+
+select f1();
+
+drop function f1();
+drop function g1();
+
+create function f1()
+returns int as $$
+declare r int;
+begin
+  if false then
+    r := a + b;
+  end if;
+  return r;
+end;
+$$ language plpgsql;
+
+select f1();
+
+drop function f1();
+
+create or replace function f1()
+returns void as $$
+begin
+  if false then
+    raise notice '%', 1, 2;
+  end if;
+end;
+$$ language plpgsql;
+
+select f1();
+
+drop function f1();
+
+create or replace function f1()
+returns void as $$
+begin
+  if false then
+    raise notice '% %';
+  end if;
+end;
+$$ language plpgsql;
+
+select f1();
+
+drop function f1();
+
+create or replace function f1()
+returns void as $$
+declare r int[];
+begin
+  if false then
+    r[c+10] := 20;
+  end if;
+end;
+$$ language plpgsql;
+
+select f1();
+
+drop function f1();
+
+
+create or replace function f1()
+returns void as $$
+declare r int;
+begin
+  if false then
+    r[10] := 20;
+  end if;
+end;
+$$ language plpgsql;
+
+select f1();
+
+drop function f1();
+
+create type _exception_type as (
+  state text,
+  message text,
+  detail text);
+
+create or replace function f1()
+returns void as $$
+declare
+  _exception record;
+begin
+  _exception := NULL::_exception_type;
+exception when others then
+  get stacked diagnostics
+        _exception.state = RETURNED_SQLSTATE,
+        _exception.message = MESSAGE_TEXT,
+        _exception.detail = PG_EXCEPTION_DETAIL,
+        _exception.hint = PG_EXCEPTION_HINT;
+end;
+$$ language plpgsql;
+
+select f1();
+
+drop function f1();


### PR DESCRIPTION
I noticed compiler warnings crept up for this module when building against PostgreSQL 9.3 or 9.3, complaining about:

plpgsql_lint.c:1361:4: warning: implicit declaration of function ‘heap_freetuple’ [-Wimplicit-function-declaration]

due to the reorganization of htup.h into htup_details.h. Also, there was no 'make check' support for 9.3. Fixed these issues, plpgsql_lint seems to work OK on 9.3 now.
